### PR TITLE
Update for changed ControlSystemAdapter interface

### DIFF
--- a/chimeraTKApp/src/ChimeraTK/EPICS/ArrayRecordDeviceSupport.h
+++ b/chimeraTKApp/src/ChimeraTK/EPICS/ArrayRecordDeviceSupport.h
@@ -118,12 +118,13 @@ protected:
    */
   void updateTimeStamp(VersionNumber const &versionNumber) {
     auto time = versionNumber.getTime();
-    double timeInNanosecs = std::chrono::time_point_cast<std::chrono::nanoseconds>(time).time_since_epoch().count();
-    uint64_t secs = std::floor(timeInNanosecs / 1.e9);
+    std::chrono::nanoseconds::rep timeInNanosecs = std::chrono::time_point_cast<std::chrono::nanoseconds>(time).
+                                                   time_since_epoch().count();
+    std::chrono::seconds::rep secs = timeInNanosecs / 1e9;
     record->time.secPastEpoch =
         (secs < POSIX_TIME_AT_EPICS_EPOCH) ?
             0 : (secs - POSIX_TIME_AT_EPICS_EPOCH);
-    record->time.nsec = timeInNanosecs - secs*1e9;
+    record->time.nsec = timeInNanosecs % 1e9;
   }
 
 private:

--- a/chimeraTKApp/src/ChimeraTK/EPICS/ArrayRecordDeviceSupport.h
+++ b/chimeraTKApp/src/ChimeraTK/EPICS/ArrayRecordDeviceSupport.h
@@ -120,11 +120,11 @@ protected:
     auto time = versionNumber.getTime();
     std::chrono::nanoseconds::rep timeInNanosecs = std::chrono::time_point_cast<std::chrono::nanoseconds>(time).
                                                    time_since_epoch().count();
-    std::chrono::seconds::rep secs = timeInNanosecs / 1e9;
+    std::chrono::seconds::rep secs = timeInNanosecs / 1000000000;
     record->time.secPastEpoch =
         (secs < POSIX_TIME_AT_EPICS_EPOCH) ?
             0 : (secs - POSIX_TIME_AT_EPICS_EPOCH);
-    record->time.nsec = timeInNanosecs % 1e9;
+    record->time.nsec = timeInNanosecs % 1000000000;
   }
 
 private:

--- a/chimeraTKApp/src/ChimeraTK/EPICS/ArrayRecordDeviceSupport.h
+++ b/chimeraTKApp/src/ChimeraTK/EPICS/ArrayRecordDeviceSupport.h
@@ -116,11 +116,14 @@ protected:
   /**
    * Updates the record's TIME field with the specified time stamp.
    */
-  void updateTimeStamp(TimeStamp const &timeStamp) {
+  void updateTimeStamp(VersionNumber const &versionNumber) {
+    auto time = versionNumber.getTime();
+    double timeInNanosecs = std::chrono::time_point_cast<std::chrono::nanoseconds>(time).time_since_epoch().count();
+    uint64_t secs = std::floor(timeInNanosecs / 1.e9);
     record->time.secPastEpoch =
-        (timeStamp.seconds < POSIX_TIME_AT_EPICS_EPOCH) ?
-            0 : (timeStamp.seconds - POSIX_TIME_AT_EPICS_EPOCH);
-    record->time.nsec = timeStamp.nanoSeconds;
+        (secs < POSIX_TIME_AT_EPICS_EPOCH) ?
+            0 : (secs - POSIX_TIME_AT_EPICS_EPOCH);
+    record->time.nsec = timeInNanosecs - secs*1e9;
   }
 
 private:
@@ -230,9 +233,9 @@ private:
   std::exception_ptr notifyException;
 
   /**
-   * Time stamp that belongs to notifyValue.
+   * Version number / time stamp that belongs to notifyValue.
    */
-  TimeStamp notifyTimeStamp;
+  VersionNumber notifyVersionNumber;
 
   /**
    * Value that was sent with last notification. This is actually a pointer to a
@@ -247,9 +250,9 @@ private:
   std::exception_ptr readException;
 
   /**
-   * Time stamp that belongs to readValue.
+   * Version number / Time stamp that belongs to readValue.
    */
-  TimeStamp readTimeStamp;
+  VersionNumber readVersionNumber;
 
   /**
    * Value that was read by last read attempt. This is actually a pointer to a
@@ -278,10 +281,9 @@ private:
       pvSupport->notify(
         [this](
             typename PVSupport<T>::SharedValue const &value,
-            TimeStamp const &timeStamp,
             VersionNumber const &versionNumber) {
           this->notifyValue = value;
-          this->notifyTimeStamp = timeStamp;
+          this->notifyVersionNumber = versionNumber;
           ensureScanIoRequest(this->ioIntrModeScanPvt);
         },
         [this](std::exception_ptr const& error){
@@ -349,7 +351,7 @@ private:
         value->data(),
         this->record->nelm * sizeof(T));
       this->record->nord = this->record->nelm;
-      this->updateTimeStamp(this->readTimeStamp);
+      this->updateTimeStamp(this->readVersionNumber);
       return;
     }
 
@@ -379,7 +381,7 @@ private:
         value->data(),
         this->record->nelm * sizeof(T));
       this->record->nord = this->record->nelm;
-      this->updateTimeStamp(this->notifyTimeStamp);
+      this->updateTimeStamp(this->notifyVersionNumber);
       pvSupport->notifyFinished();
       return;
     }
@@ -391,10 +393,9 @@ private:
     bool immediate = pvSupport->read(
       [this](bool immediate,
           typename PVSupport<T>::SharedValue const &value,
-          TimeStamp const &timeStamp,
           VersionNumber const &versionNumber) {
         this->readValue = value;
-        this->readTimeStamp = timeStamp;
+        this->readVersionNumber = versionNumber;
         if (!immediate) {
           ::callbackRequestProcessCallback(
             &this->processCallback, priorityMedium, this->record);

--- a/chimeraTKApp/src/ChimeraTK/EPICS/ControlSystemAdapterPVSupportDef.h
+++ b/chimeraTKApp/src/ChimeraTK/EPICS/ControlSystemAdapterPVSupportDef.h
@@ -107,7 +107,7 @@ public:
   virtual std::size_t getNumberOfElements() override;
 
   // Declared in PVSupport.
-  virtual std::tuple<Value, TimeStamp, VersionNumber> initialValue() override;
+  virtual std::tuple<Value, VersionNumber> initialValue() override;
 
   // Declared in PVSupport.
   virtual void notify(

--- a/chimeraTKApp/src/ChimeraTK/EPICS/ControlSystemAdapterPVSupportImpl.h
+++ b/chimeraTKApp/src/ChimeraTK/EPICS/ControlSystemAdapterPVSupportImpl.h
@@ -80,7 +80,7 @@ std::size_t ControlSystemAdapterPVSupport<T>::getNumberOfElements() {
 }
 
 template<typename T>
-std::tuple<typename PVSupport<T>::Value, TimeStamp, VersionNumber> ControlSystemAdapterPVSupport<T>::initialValue() {
+std::tuple<typename PVSupport<T>::Value, VersionNumber> ControlSystemAdapterPVSupport<T>::initialValue() {
   return this->shared->initialValue();
 }
 

--- a/chimeraTKApp/src/ChimeraTK/EPICS/ControlSystemAdapterSharedPVSupportDef.h
+++ b/chimeraTKApp/src/ChimeraTK/EPICS/ControlSystemAdapterSharedPVSupportDef.h
@@ -168,7 +168,7 @@ public:
    * in an exception because the initial value is not available any longer after
    * such an action.
    */
-  std::tuple<Value, TimeStamp, VersionNumber> initialValue();
+  std::tuple<Value, VersionNumber> initialValue();
 
   /**
    * Reads the next available value and calls the callback. if there are PV
@@ -229,20 +229,15 @@ private:
   bool alreadyReadNewValue;
 
   /**
-   * Time stamp belonging to the value stored in lastValueRead.
+   * Version number / time stamp belonging to the value stored in lastValueRead.
    */
-  TimeStamp lastTimeStampRead;
+  VersionNumber lastVersionNumberRead;
 
   /**
    * Last value that his been read. This value might have been read by the
    * doNotify() or the read(...) method.
    */
   std::shared_ptr<Value const> lastValueRead;
-
-  /**
-   * Version number belonging to the value stored in lastValueRead.
-   */
-  VersionNumber lastVersionNumberRead;
 
   /**
    * Flag indicating whether the initial value is still available. This flag is

--- a/chimeraTKApp/src/ChimeraTK/EPICS/ConvertingPVSupport.h
+++ b/chimeraTKApp/src/ChimeraTK/EPICS/ConvertingPVSupport.h
@@ -102,12 +102,11 @@ public:
   }
 
   // Declared in PVSupport.
-  std::tuple<Value, TimeStamp, VersionNumber> initialValue() override {
+  std::tuple<Value, VersionNumber> initialValue() override {
     auto original = originalPVSupport->initialValue();
     return std::make_tuple(
       convertToTarget(std::get<0>(original)),
-      std::get<1>(original),
-      std::get<2>(original));
+      std::get<1>(original));
   }
 
   // Declared in PVSupport.
@@ -119,9 +118,8 @@ public:
     if (successCallback) {
       wrappedSuccessCallback = [successCallback](
             typename PVSupport<OriginalType>::SharedValue const &value,
-            TimeStamp const &timeStamp,
             VersionNumber const &versionNumber){
-          successCallback(convertToTarget(value), timeStamp, versionNumber);
+          successCallback(convertToTarget(value), versionNumber);
         };
     }
     if (errorCallback) {
@@ -147,10 +145,9 @@ public:
       wrappedSuccessCallback = [successCallback](
             bool immediate,
             typename PVSupport<OriginalType>::SharedValue const &value,
-            TimeStamp const &timeStamp,
             VersionNumber const &versionNumber){
           successCallback(
-            immediate, convertToTarget(value), timeStamp, versionNumber);
+            immediate, convertToTarget(value), versionNumber);
         };
     }
     if (errorCallback) {

--- a/chimeraTKApp/src/ChimeraTK/EPICS/DeviceAccessPVSupport.h
+++ b/chimeraTKApp/src/ChimeraTK/EPICS/DeviceAccessPVSupport.h
@@ -89,7 +89,7 @@ public:
   virtual std::size_t getNumberOfElements() override;
 
   // Declared in PVSupport.
-  virtual std::tuple<Value, TimeStamp, VersionNumber> initialValue() override;
+  virtual std::tuple<Value, VersionNumber> initialValue() override;
 
   // Declared in PVSupport.
   virtual bool read(
@@ -148,13 +148,12 @@ std::size_t DeviceAccessPVSupport<T>::getNumberOfElements() {
 }
 
 template<typename T>
-std::tuple<typename PVSupport<T>::Value, TimeStamp, VersionNumber> DeviceAccessPVSupport<T>::initialValue() {
+std::tuple<typename PVSupport<T>::Value, VersionNumber> DeviceAccessPVSupport<T>::initialValue() {
   this->accessor.read();
   Value value(this->accessor.getNElements());
   this->accessor.swap(value);
   return std::make_tuple(
       std::move(value),
-      TimeStamp(),
       VersionNumber());
 }
 
@@ -187,7 +186,6 @@ bool DeviceAccessPVSupport<T>::read(
       }
       try {
         successCallback(false, std::make_shared<Value const>(std::move(value)),
-          TimeStamp(),
           VersionNumber());
       } catch (std::exception &e) {
         errorPrintf(

--- a/chimeraTKApp/src/ChimeraTK/EPICS/FixedScalarRecordDeviceSupport.h
+++ b/chimeraTKApp/src/ChimeraTK/EPICS/FixedScalarRecordDeviceSupport.h
@@ -141,11 +141,11 @@ protected:
     auto time = versionNumber.getTime();
     std::chrono::nanoseconds::rep timeInNanosecs = std::chrono::time_point_cast<std::chrono::nanoseconds>(time).
                                                    time_since_epoch().count();
-    std::chrono::seconds::rep secs = timeInNanosecs / 1e9;
+    std::chrono::seconds::rep secs = timeInNanosecs / 1000000000;
     record->time.secPastEpoch =
         (secs < POSIX_TIME_AT_EPICS_EPOCH) ?
             0 : (secs - POSIX_TIME_AT_EPICS_EPOCH);
-    record->time.nsec = timeInNanosecs % 1e9;
+    record->time.nsec = timeInNanosecs % 1000000000;
   }
 
 };

--- a/chimeraTKApp/src/ChimeraTK/EPICS/FixedScalarRecordDeviceSupport.h
+++ b/chimeraTKApp/src/ChimeraTK/EPICS/FixedScalarRecordDeviceSupport.h
@@ -139,12 +139,13 @@ protected:
    */
   void updateTimeStamp(VersionNumber const &versionNumber) {
     auto time = versionNumber.getTime();
-    double timeInNanosecs = std::chrono::time_point_cast<std::chrono::nanoseconds>(time).time_since_epoch().count();
-    uint64_t secs = std::floor(timeInNanosecs / 1.e9);
+    std::chrono::nanoseconds::rep timeInNanosecs = std::chrono::time_point_cast<std::chrono::nanoseconds>(time).
+                                                   time_since_epoch().count();
+    std::chrono::seconds::rep secs = timeInNanosecs / 1e9;
     record->time.secPastEpoch =
         (secs < POSIX_TIME_AT_EPICS_EPOCH) ?
             0 : (secs - POSIX_TIME_AT_EPICS_EPOCH);
-    record->time.nsec = timeInNanosecs - secs*1e9;
+    record->time.nsec = timeInNanosecs % 1e9;
   }
 
 };

--- a/chimeraTKApp/src/ChimeraTK/EPICS/PVSupport.h
+++ b/chimeraTKApp/src/ChimeraTK/EPICS/PVSupport.h
@@ -28,7 +28,6 @@
 #include <tuple>
 #include <vector>
 
-#include <ChimeraTK/TimeStamp.h>
 #include <ChimeraTK/VersionNumber.h>
 
 namespace ChimeraTK {
@@ -148,7 +147,7 @@ public:
    * Type of the callback function that is called when a new value is available.
    * Such a function can be registered by calling notify(...);
    */
-  using NotifyCallback = std::function<void(SharedValue const &, TimeStamp const &, VersionNumber const &)>;
+  using NotifyCallback = std::function<void(SharedValue const &, VersionNumber const &)>;
 
   /**
    * Type of the callback function that is called when there is an error for a
@@ -163,7 +162,7 @@ public:
    * read(...) returns (true) or it is called at a later point in time, after
    * read(...) has returned (false).
    */
-  using ReadCallback = std::function<void(bool, SharedValue const &, TimeStamp const &, VersionNumber const &)>;
+  using ReadCallback = std::function<void(bool, SharedValue const &, VersionNumber const &)>;
 
   /**
    * Type of the callback function that is called when a value is successfully
@@ -206,7 +205,7 @@ public:
    * This method throws an exception when the implementation cannot provide an
    * initial value for the respective process variable.
    */
-  virtual std::tuple<Value, TimeStamp, VersionNumber> initialValue();
+  virtual std::tuple<Value, VersionNumber> initialValue();
 
   /**
    * Requests notifications. The successCallback is called every time there is


### PR DESCRIPTION
In the ControlSystemAdapter the TimeStamp class was removed and the time stamp was integrated into the VersionNumber. This requires all adapters to update to the new API.