### PR TITLE
fix: Use pkg-config instead of custom script

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,6 @@ Installation
 Please copy `configure/EXAMPLE_RELEASE.local` to `configure/RELEASE.local` and
 adjust the path to EPICS Base.
 
-Usually, the build system automatically detects the correct compiler and linker
-flags. However, if the `ChimeraTK-ControlSystemAdapter-config` script is not in
-the `PATH`, you have to specify the path to these scripts explicitly. In this
-case, please copy `configure/EXAMPLE_CONFIG_SITE.local` to
-`configure/CONFIG_SITE.local` and adjust the paths to these scripts.
-
 The ChimeraTK Control System Adapter for EPICS needs the
 [ChimeraTK Control System Adapter core library](https://github.com/ChimeraTK/ControlSystemAdapter/).
 

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -30,11 +30,6 @@ CHECK_RELEASE = YES
 #   a Microsoft FTP server say, or on some NFS configurations.
 #IOCS_APPL_TOP = </IOC's/absolute/path/to/install/top>
 
-# Path to the ChimeraTK-ControlSystemAdapter-config executable. By default, it
-# is expected to be in the PATH, but one can override this by setting this
-# variable to the full path to the executable.
-CHIMERATK_CONTROL_SYSTEM_ADAPTER_CONFIG = ChimeraTK-ControlSystemAdapter-config
-
 # Allow user to override settings locally.
 -include $(TOP)/configure/CONFIG_SITE.local
 
@@ -44,9 +39,9 @@ CHIMERATK_CONTROL_SYSTEM_ADAPTER_CONFIG = ChimeraTK-ControlSystemAdapter-config
 # CONFIG_SITE.local.
 
 ifndef CHIMERATK_SKIP_CXXFLAGS
-  USR_CXXFLAGS += $(shell $(CHIMERATK_CONTROL_SYSTEM_ADAPTER_CONFIG) --cppflags)
+  USR_CXXFLAGS += $(shell $(pkg-config ChimeraTK-ControlSystemAdapter) --cflags)
 endif
 
 ifndef CHIMERATK_SKIP_LDFLAGS
-  USR_LDFLAGS += $(shell $(CHIMERATK_CONTROL_SYSTEM_ADAPTER_CONFIG) --ldflags)
+  USR_LDFLAGS += $(shell $(pkg-config ChimeraTK-ControlSystemAdapter) --libs)
 endif

--- a/configure/EXAMPLE_CONFIG_SITE.local
+++ b/configure/EXAMPLE_CONFIG_SITE.local
@@ -1,4 +1,0 @@
-# Path to the ChimeraTK-ControlSystemAdapter-config executable. You only have to
-# define this, if it is not in the PATH.
-CHIMERATK_CONTROL_SYSTEM_ADAPTER_CONFIG = /path/to/ChimeraTK-ControlSystemAdapter-config
-

--- a/examples/device-access/configure/CONFIG_SITE
+++ b/examples/device-access/configure/CONFIG_SITE
@@ -35,11 +35,6 @@ CHECK_RELEASE = YES
 #HOST_OPT = NO
 #CROSS_OPT = NO
 
-# Path to the ChimeraTK-ControlSystemAdapter-config executable. By default, it
-# is expected to be in the PATH, but one can override this by setting this
-# variable to the full path to the executable in CONFIG_SITE.local.
-CHIMERATK_CONTROL_SYSTEM_ADAPTER_CONFIG = ChimeraTK-ControlSystemAdapter-config
-
 # These allow developers to override the CONFIG_SITE variable
 # settings without having to modify the configure/CONFIG_SITE
 # file itself.
@@ -56,5 +51,5 @@ CHIMERATK_CONTROL_SYSTEM_ADAPTER_CONFIG = ChimeraTK-ControlSystemAdapter-config
 # the libraries if we do not include the linker flags here.
 
 ifndef CHIMERATK_SKIP_LDFLAGS
-  USR_LDFLAGS += $(shell $(CHIMERATK_CONTROL_SYSTEM_ADAPTER_CONFIG) --ldflags)
+  USR_LDFLAGS += $(shell $(pkg-config ChimeraTK-ControlSystemAdapter) --libs)
 endif


### PR DESCRIPTION
We have removed the custom -config script. It has been replaced by using
the supplied pkg-config files
