### PR TITLE
fix: use of pkg-config

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -39,9 +39,9 @@ CHECK_RELEASE = YES
 # CONFIG_SITE.local.
 
 ifndef CHIMERATK_SKIP_CXXFLAGS
-  USR_CXXFLAGS += $(shell $(pkg-config ChimeraTK-ControlSystemAdapter) --cflags)
+  USR_CXXFLAGS += $(shell pkg-config ChimeraTK-ControlSystemAdapter --cflags)
 endif
 
 ifndef CHIMERATK_SKIP_LDFLAGS
-  USR_LDFLAGS += $(shell $(pkg-config ChimeraTK-ControlSystemAdapter) --libs)
+  USR_LDFLAGS += $(shell pkg-config ChimeraTK-ControlSystemAdapter --libs)
 endif

--- a/examples/device-access/configure/CONFIG_SITE
+++ b/examples/device-access/configure/CONFIG_SITE
@@ -51,5 +51,5 @@ CHECK_RELEASE = YES
 # the libraries if we do not include the linker flags here.
 
 ifndef CHIMERATK_SKIP_LDFLAGS
-  USR_LDFLAGS += $(shell $(pkg-config ChimeraTK-ControlSystemAdapter) --libs)
+  USR_LDFLAGS += $(shell pkg-config ChimeraTK-ControlSystemAdapter --libs)
 endif


### PR DESCRIPTION
This is a fix for ff143a4c89, which has a syntax error when using pkg-config.

Please also generate a new tag.